### PR TITLE
Add between filter

### DIFF
--- a/reqon/terms.py
+++ b/reqon/terms.py
@@ -500,8 +500,8 @@ def between(reql, _from, _to, index = None):
     if isinstance(lower, datetime.datetime) and isinstance(upper, datetime.datetime):
         timezone = get_time_zone(lower)
         return reql.between(
-            r.time(lower.year, lower.month, lower.day, timezone),
-            r.time(upper.year, upper.month, upper.day, timezone),
+            r.time(lower.year, lower.month, lower.day, lower.hour, lower.minute, lower.second, timezone),
+            r.time(upper.year, upper.month, upper.day, upper.hour, upper.minute, upper.second, timezone),
             **options
         )
     else:

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -331,15 +331,15 @@ class TermsTests(ReQONTestMixin, unittest.TestCase):
 
 
     def test_between(self):
-        _from = r.time(2016, 1, 1, 'Z')
-        _to = r.time(2016, 1, 31, 'Z')
+        _from = r.time(2016, 1, 1, 0, 0, 0,'Z')
+        _to = r.time(2016, 1, 31, 0, 0, 0, 'Z')
         reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, '2016-01-01', '2016-01-31', 'timestamp'))
         reql2 = self.reqlify(lambda: self.reql.between(_from, _to, index = 'timestamp'))
         assert str(reql1) == str(reql2)
 
     def test_nil_index(self):
-        _from = r.time(2016, 1, 1, 'Z')
-        _to = r.time(2016, 1, 31, 'Z')
+        _from = r.time(2016, 1, 1, 0, 0, 0, 'Z')
+        _to = r.time(2016, 1, 31, 0, 0, 0, 'Z')
         reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, '2016-01-01', '2016-01-31'))
         reql2 = self.reqlify(lambda: self.reql.between(_from, _to))
         assert str(reql1) == str(reql2)

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -325,3 +325,26 @@ class TermsTests(ReQONTestMixin, unittest.TestCase):
         with pytest.raises(reqon.exceptions.InvalidTypeError) as excinfo:
             terms.max_(self.reql, 1)
         assert terms.ERRORS['type']['string'].format('max_') == str(excinfo.value)
+
+
+    # Between
+
+
+    def test_between(self):
+        _from = r.time(2016, 1, 1, 'Z')
+        _to = r.time(2016, 1, 31, 'Z')
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, '2016-01-01', '2016-01-31', 'timestamp'))
+        reql2 = self.reqlify(lambda: self.reql.between(_from, _to, index = 'timestamp'))
+        assert str(reql1) == str(reql2)
+
+    def test_nil_index(self):
+        _from = r.time(2016, 1, 1, 'Z')
+        _to = r.time(2016, 1, 31, 'Z')
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, '2016-01-01', '2016-01-31'))
+        reql2 = self.reqlify(lambda: self.reql.between(_from, _to))
+        assert str(reql1) == str(reql2)
+
+    def test_between_without_strings(self):
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, 'ab', 'ef'))
+        reql2 = self.reqlify(lambda: self.reql.between('ab', 'ef'))
+        assert str(reql1) == str(reql2)


### PR DESCRIPTION
This adds the between filter. Currently we are only accepting a lower
value, and upper value, and an optional index. We are opting out of the
lower and upper bound options for now, as well as the ability to use an
array as the lower or upper bound.

Fixes #5
