### PR TITLE
Fix array breaking expand path

### DIFF
--- a/reqon/terms.py
+++ b/reqon/terms.py
@@ -42,7 +42,7 @@ def _expand_path(fields):
         Raises a "reqon.exceptions.InvalidTypeError" if the argument is not a String
     '''
 
-    try:
+    if isinstance(fields, six.string_types):
         fields = fields.split('.')
         num_fields = len(fields)
         if num_fields == 1:
@@ -55,8 +55,8 @@ def _expand_path(fields):
                 node[field] = {}
                 node = node[field]
         return row
-    except:
-        raise InvalidTypeError(ERRORS['type']['string'].format('expand_path'))
+    else:
+        return fields
 
 
 # Selecting data

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -19,11 +19,10 @@ class TermsTests(ReQONTestMixin, unittest.TestCase):
         expected = {'foo': { 'bar': { 'baz': True } } }
         assert expected == expanded
 
-    def test_expand_path_invalid_type(self):
-        with pytest.raises(reqon.exceptions.InvalidTypeError) as excinfo:
-            terms._expand_path(1)
-        assert terms.ERRORS['type']['string'].format('expand_path') == str(excinfo.value)
-
+    def test_expand_path_with_array(self):
+        expanded = terms._expand_path([1, 2, 3])
+        expected = [1, 2, 3]
+        assert expanded == expected
 
     # Get
 


### PR DESCRIPTION
This fixes a bug where passing in an array to a query would break the
_expand_path method. If a value is passed in that is not a string, it
should simply get passed through as is, otherwise it should get split
into a dictionary. This adds an explicit type check.

Fixes #6
