### PR TITLE
Fix between operator

### DIFF
--- a/reqon/terms.py
+++ b/reqon/terms.py
@@ -464,7 +464,7 @@ def max_(reql, value):
     '''
     return reql.max(_expand_path(value))
 
-def between(reql, _from, _to, index = None):
+def between(reql, args):
     '''
         Adds a 'between' filter to the query
         ['$between', ['2016-01-01', '2016-01-31', 'timestamp']]
@@ -489,6 +489,12 @@ def between(reql, _from, _to, index = None):
             return value.isoformat().split('+')[1]
         except:
             return 'Z'
+
+    if len(args) == 2:
+        _from, _to = args
+        index = None
+    else:
+        _from, _to, index = args
 
     options = {}
     lower = parse_arg(_from)

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -332,18 +332,18 @@ class TermsTests(ReQONTestMixin, unittest.TestCase):
     def test_between(self):
         _from = r.time(2016, 1, 1, 0, 0, 0,'Z')
         _to = r.time(2016, 1, 31, 0, 0, 0, 'Z')
-        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, '2016-01-01', '2016-01-31', 'timestamp'))
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, ['2016-01-01', '2016-01-31', 'timestamp']))
         reql2 = self.reqlify(lambda: self.reql.between(_from, _to, index = 'timestamp'))
         assert str(reql1) == str(reql2)
 
     def test_nil_index(self):
         _from = r.time(2016, 1, 1, 0, 0, 0, 'Z')
         _to = r.time(2016, 1, 31, 0, 0, 0, 'Z')
-        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, '2016-01-01', '2016-01-31'))
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, ['2016-01-01', '2016-01-31']))
         reql2 = self.reqlify(lambda: self.reql.between(_from, _to))
         assert str(reql1) == str(reql2)
 
     def test_between_without_strings(self):
-        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, 'ab', 'ef'))
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, ['ab', 'ef']))
         reql2 = self.reqlify(lambda: self.reql.between('ab', 'ef'))
         assert str(reql1) == str(reql2)


### PR DESCRIPTION
This fixes the issue where the between operator wasn't accepting an
array as the second argument. I had initially believed that this was
being unpacked, but that was not the case.

Fixes #10 

@dmpayton We should get this merged in and up on Montage ASAP. Aggregator needs this to work.
