### PR TITLE
Fix order_by term

### DIFF
--- a/reqon/terms.py
+++ b/reqon/terms.py
@@ -184,7 +184,9 @@ def order_by(reql, value):
     '''
         Adds an 'order_by' filter to the query
         ['$order_by', 'name']
+        ['$order_by', ['name', '$desc']]
         ['$order_by', ['$index', 'name']]
+        ['$order_by', ['$index', 'name', $asc']]
 
         Arguments:
         reql -- The reql query to append to
@@ -197,7 +199,16 @@ def order_by(reql, value):
         No custom exceptions are currently raised
     '''
     if isinstance(value, list) and value[0] == '$index':
-        return reql.order_by(index=value[1])
+        if len(value) == 2:
+            return reql.order_by(index=value[1])
+        elif len(value) == 3 and value[2] == '$asc':
+            return reql.order_by(index=r.asc(value[1]))
+        elif len(value) == 3 and value[2] == '$desc':
+            return reql.order_by(index=r.desc(value[1]))
+    elif isinstance(value, list) and value[1] == '$asc':
+        return reql.order_by(r.asc(value[0]))
+    elif isinstance(value, list) and value[1] == '$desc':
+        return reql.order_by(r.desc(value[0]))
     return reql.order_by(_expand_path(value))
 
 

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -105,6 +105,26 @@ class TermsTests(ReQONTestMixin, unittest.TestCase):
         reql2 = self.reqlify(lambda: self.reql.order_by(index='title'))
         assert str(reql1) == str(reql2)
 
+    def test_order_by_ascending(self):
+        reql1 = self.reqlify(lambda: reqon.TERMS['$order_by'](self.reql, ['rank', '$asc']))
+        reql2 = self.reqlify(lambda: self.reql.order_by(r.asc('rank')))
+        assert str(reql1) == str(reql2)
+
+    def test_order_by_descending(self):
+        reql1 = self.reqlify(lambda: reqon.TERMS['$order_by'](self.reql, ['rank', '$desc']))
+        reql2 = self.reqlify(lambda: self.reql.order_by(r.desc('rank')))
+        assert str(reql1) == str(reql2)
+
+    def test_order_by_asc_indexed(self):
+        reql1 = self.reqlify(lambda: reqon.TERMS['$order_by'](self.reql, ['$index', 'rank', '$asc']))
+        reql2 = self.reqlify(lambda: self.reql.order_by(index=r.asc('rank')))
+        assert str(reql1) == str(reql2)
+
+    def test_order_by_desc_indexed(self):
+        reql1 = self.reqlify(lambda: reqon.TERMS['$order_by'](self.reql, ['$index', 'rank', '$desc']))
+        reql2 = self.reqlify(lambda: self.reql.order_by(index=r.desc('rank')))
+        assert str(reql1) == str(reql2)
+
 
     # Skip
 


### PR DESCRIPTION
This fixes the order by term to accept an ordering direction.

Fixes #9 

@dmpayton Take a look at the implementation on this one. I'm not sure I like the API, but I just made a quick change that works for now.
