### PR TITLE
Fix between query parsing

### DIFF
--- a/reqon/terms.py
+++ b/reqon/terms.py
@@ -497,11 +497,15 @@ def between(reql, args):
         _from, _to, index = args
 
     options = {}
-    lower = parse_arg(_from)
-    upper = parse_arg(_to)
 
     if index:
        options['index'] = index
+
+    if isinstance(_from, int):
+        return reql.between(_from, _to, **options)
+
+    lower = parse_arg(_from)
+    upper = parse_arg(_to)
 
     if isinstance(lower, datetime.datetime) and isinstance(upper, datetime.datetime):
         timezone = get_time_zone(lower)

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -343,7 +343,12 @@ class TermsTests(ReQONTestMixin, unittest.TestCase):
         reql2 = self.reqlify(lambda: self.reql.between(_from, _to))
         assert str(reql1) == str(reql2)
 
-    def test_between_without_strings(self):
+    def test_between_with_strings(self):
         reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, ['ab', 'ef']))
         reql2 = self.reqlify(lambda: self.reql.between('ab', 'ef'))
+        assert str(reql1) == str(reql2)
+
+    def test_between_with_int(self):
+        reql1 = self.reqlify(lambda: reqon.TERMS['$between'](self.reql, [1, 2, "foo"]))
+        reql2 = self.reqlify(lambda: self.reql.between(1, 2, index="foo"))
         assert str(reql1) == str(reql2)


### PR DESCRIPTION
This fixes the parsing of the between query. It looks like the
`dateutil.parser` blows up when an integer is passed to it. Now we are
type checking to see if an integer is passed in and if so, just passing
it through before attempting a dateutil.parse.

@dmpayton This fixes a bug. However, it does not affect Aggregator's current use case, as Aggregator is currently using dates for the between operator, and that currently works.
